### PR TITLE
Soft dependency on Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "nodeunit test"
   },
   "engines": {
-    "node": "~0.6.6"
+    "node": ">=0.6.6"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Hello, @arokor,

We trying to use the `engine-strict` option for some of our projects and unfortunately the `timely` package strictly required the `0.6.6` version.

> You can also use the “engines” field to specify which versions of npm are capable of properly installing your program. For example:
> `{ "engines" : { "npm" : "~1.0.20" } }`
> Unless the user has set the `engine-strict` config flag, this field is advisory only and will only produce warnings when your package is installed as a dependency.
> https://docs.npmjs.com/files/package.json#engines

This package does not use any Node.js API's, so I think we can safely introduce soft dependency on Node.js version.